### PR TITLE
Add Http4sMatchers from http4s-testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.class
 *.log
+**/target

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,15 @@
+val specs2Version = "4.9.2"
+val http4sVersion = "0.21.3"
+
+lazy val specs2Http4s = (project in file("."))
+  .settings(
+    name := "specs2-http4s",
+    organization := "org.specs2",
+    scalaVersion := "2.13.1",
+    libraryDependencies ++= Seq(
+      "org.specs2" %% "specs2-matcher" % specs2Version,
+      "org.specs2" %% "specs2-cats" % specs2Version,
+      "org.http4s" %% "http4s-core" % http4sVersion,
+      "org.specs2" %% "specs2-core" % specs2Version % Test
+    )
+  )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.9

--- a/src/main/scala/org/specs2/matcher/Http4sMatchers.scala
+++ b/src/main/scala/org/specs2/matcher/Http4sMatchers.scala
@@ -1,0 +1,64 @@
+package org.specs2.matcher
+
+import cats.MonadError
+import cats.implicits._
+import org.http4s._
+import org.http4s.headers.{`Content-Encoding`, `Content-Type`}
+
+trait Http4sMatchers[F[_]] extends Matchers with RunTimedMatchers[F] {
+
+  def haveStatus(expected: Status): Matcher[Response[F]] =
+    be_===(expected) ^^ { r: Response[F] => r.status.aka("the response status") }
+
+  def returnStatus(s: Status): Matcher[F[Response[F]]] =
+    returnValue(haveStatus(s)) ^^ { (m: F[Response[F]]) => m.aka("the returned response status") }
+
+  def haveBody[A](a: ValueCheck[A])(
+      implicit F: MonadError[F, Throwable],
+      ee: EntityDecoder[F, A]
+  ): Matcher[Message[F]] =
+    returnValue(a) ^^ { (m: Message[F]) => m.as[A].aka("the message body") }
+
+  def returnBody[A](a: ValueCheck[A])(
+      implicit F: MonadError[F, Throwable],
+      ee: EntityDecoder[F, A]
+  ): Matcher[F[Message[F]]] =
+    returnValue(a) ^^ { (m: F[Message[F]]) => m.flatMap(_.as[A]).aka("the returned message body") }
+
+  def haveHeaders(hs: Headers): Matcher[Message[F]] =
+    be_===(hs) ^^ { (m: Message[F]) => m.headers.aka("the headers") }
+
+  def returnHeaders(hs: Headers): Matcher[F[Message[F]]] =
+    returnValue(haveHeaders(hs)) ^^ { (m: F[Message[F]]) => m.aka("the returned headers")}
+
+  def containHeader(h: Header): Matcher[Message[F]] =
+    beSome(h.value) ^^ { (m: Message[F]) =>
+      m.headers.get(h.name).map(_.value).aka("the particular header")
+    }
+
+  def returnContainingHeader(h: Header): Matcher[F[Message[F]]] =
+    returnValue(containHeader(h)) ^^ { (m: F[Message[F]]) =>
+      m.aka("the returned particular header")
+    }
+
+  def haveMediaType(mt: MediaType): Matcher[Message[F]] =
+    beSome(mt) ^^ { (m: Message[F]) =>
+      m.headers.get(`Content-Type`).map(_.mediaType).aka("the media type header")
+    }
+
+  def returnMediaType(mt: MediaType): Matcher[F[Message[F]]] =
+    returnValue(haveMediaType(mt)) ^^ { (m: F[Message[F]]) =>
+      m.aka("the returned media type header")
+    }
+
+  def haveContentCoding(c: ContentCoding): Matcher[Message[F]] =
+    beSome(c) ^^ { (m: Message[F]) =>
+      m.headers.get(`Content-Encoding`).map(_.contentCoding).aka("the content encoding header")
+    }
+
+  def returnContentCoding(c: ContentCoding): Matcher[F[Message[F]]] =
+    returnValue(haveContentCoding(c)) ^^ { (m: F[Message[F]]) =>
+      m.aka("the returned content encoding header")
+    }
+
+}

--- a/src/test/scala/org/specs2/matcher/Http4sMatchersSpec.scala
+++ b/src/test/scala/org/specs2/matcher/Http4sMatchersSpec.scala
@@ -1,0 +1,89 @@
+package org.specs2.matcher
+
+import cats.effect.IO
+import org.http4s._
+import org.http4s.headers.{Accept, Host, `Content-Encoding`, `Content-Type`}
+import org.specs2.Spec
+
+
+class Http4sMatchersSpec extends Spec with Http4sMatchers[IO] with IOMatchers { def is = s2"""
+    
+    haveStatus checks that a Response's HTTP status is the expected value
+    ${Response[IO](Status.Ok) must haveStatus(Status.Ok)}
+    ${Response[IO](Status.NotFound) must not(haveStatus(Status.Ok))}
+
+    returnStatus checks that an effectful Response's Http status is the expected value
+    ${IO.pure(Response[IO](Status.Ok)) must returnStatus(Status.Ok)}
+    ${IO.pure(Response[IO](Status.NotFound)) must not(returnStatus(Status.Ok))}
+
+    haveBody checks that the body of a Message decodes to the expected value
+    ${Request[IO](method = Method.POST).withEntity("abc") must haveBody("abc")}
+    ${Response[IO]().withEntity("def") must not(haveBody("abc"))}
+
+    returnBody checks that the body of an effectful Message decodes to the expected value
+    ${IO.pure(Response[IO]().withEntity("abc")) must returnBody("abc")}
+    ${IO.pure(Response[IO]().withEntity("def")) must not(returnBody("abc"))}
+
+    haveHeaders checks that the Message's headers equal the expected Headers
+    ${Request[IO]().putHeaders(Host("specs2.org")) must haveHeaders(Headers.of(Host("specs2.org")))}
+    ${Request[IO]().putHeaders(Host("specs2.org")) must not(haveHeaders(Headers.of(
+      Host("specs2.org"),
+      Accept(MediaType.text.html)
+    )))}
+
+    returnHeaders checks that the effectful Message's headers equal the expected Headers
+    ${IO.pure(Request[IO]().putHeaders(Host("specs2.org"))) must
+      returnHeaders(Headers.of(Host("specs2.org")))}
+    ${IO.pure(Request[IO]().putHeaders(Host("specs2.org"))) must not(returnHeaders(Headers.of(
+      Host("specs2.org"),
+      Accept(MediaType.text.html)
+    )))}
+
+    containHeader checks that the Message contains the expected header
+    ${Request[IO]().putHeaders(Host("specs2.org")) must containHeader(Host("specs2.org"))}
+    ${Request[IO]().putHeaders(Host("specs2.org")) must not(containHeader(Host("example.com")))}
+    ${Request[IO]().putHeaders(Host("specs2.org"), Accept(MediaType.text.html)) must containHeader(
+      Host("specs2.org"))}
+
+    returnContainingHeader checks that the effectul Message contains the expected header
+    ${IO.pure(Request[IO]().putHeaders(Host("specs2.org"))) must
+      returnContainingHeader(Host("specs2.org"))}
+    ${IO.pure(Request[IO]().putHeaders(Host("specs2.org"))) must
+      not(returnContainingHeader(Host("example.com")))}
+    ${IO.pure(Request[IO]().putHeaders(Host("specs2.org"), Accept(MediaType.text.html))) must
+      returnContainingHeader(Host("specs2.org"))}
+
+    haveMediaType checks that the Message has a Content-Type header with the expected MediaType
+    ${Request[IO](method = Method.POST).putHeaders(`Content-Type`(MediaType.text.html)) must
+      haveMediaType(MediaType.text.html)}
+    ${Request[IO](method = Method.POST).putHeaders(`Content-Type`(MediaType.text.html,
+      Charset.`UTF-8`)) must haveMediaType(MediaType.text.html)}
+    ${Request[IO](method = Method.POST).putHeaders(`Content-Type`(MediaType.text.html)) must
+      not(haveMediaType(MediaType.application.json))}
+
+    returnMediaType checks that the effectful Message has a Content-Type header with the expected
+    MediaType
+    ${IO.pure(Request[IO](method = Method.POST).putHeaders(`Content-Type`(MediaType.text.html))) must
+      returnMediaType(MediaType.text.html)}
+    ${IO.pure(Request[IO](method = Method.POST).putHeaders(`Content-Type`(MediaType.text.html,
+      Charset.`UTF-8`))) must returnMediaType(MediaType.text.html)}
+    ${IO.pure(Request[IO](method = Method.POST).putHeaders(`Content-Type`(MediaType.text.html))) must
+      not(returnMediaType(MediaType.application.json))}
+
+    haveContentCoding checks that the Message has a Content-Encoding header with the expected
+    ContentCoding
+    ${Request[IO](method = Method.POST).putHeaders(`Content-Encoding`(ContentCoding.gzip)) must
+      haveContentCoding(ContentCoding.gzip)}
+    ${Request[IO](method = Method.POST).putHeaders(`Content-Encoding`(ContentCoding.gzip)) must
+      not(haveContentCoding(ContentCoding.zstd))}
+
+    returnContentCoding checks that the effectful Message has a Content-Encoding header with the
+    expected ContentCoding
+    ${IO.pure(Request[IO](method = Method.POST).putHeaders(`Content-Encoding`(ContentCoding.gzip))) must
+      returnContentCoding(ContentCoding.gzip)}
+    ${IO.pure(Request[IO](method = Method.POST).putHeaders(`Content-Encoding`(ContentCoding.gzip))) must
+      not(returnContentCoding(ContentCoding.zstd))}
+
+  """
+
+}


### PR DESCRIPTION
Changes I've already made:
* return* matchers (except returnBody) rewritten in terms of their non-effectful counterparts instead of duplicating logic
* Added returnHeaders, returnContainingHeader, returnMediaType and returnContentCoding, to align with the other effectful matchers
* Renamed containsHeader to containHeader to fit must/should DSL better
* Removed doesntContainHeader since it's made redundant by `not`

Closes etorreborre/specs2#821